### PR TITLE
Refactor: use default variables instead of hardcoded values

### DIFF
--- a/rag_app/app.py
+++ b/rag_app/app.py
@@ -47,14 +47,14 @@ def get_available_models():
 
         # Ajouter des modèles par défaut si aucun n'est trouvé
         if not chat_models:
-            chat_models = ["mistral"]  # Valeur par défaut si aucun modèle de chat n'est trouvé
+            chat_models = [DEFAULT_CHAT_MODEL]  # Valeur par défaut si aucun modèle de chat n'est trouvé
         if not embedding_models:
-            embedding_models = ["nomic-embed-text"]  # Valeur par défaut si aucun modèle d'embedding n'est trouvé
+            embedding_models = [DEFAULT_EMBEDDING_MODEL]  # Valeur par défaut si aucun modèle d'embedding n'est trouvé
 
         return chat_models, embedding_models
     except Exception as e:
         st.error(f"Erreur lors de la récupération des modèles : {e}")
-        return ["mistral"], ["nomic-embed-text"]
+        return [DEFAULT_CHAT_MODEL], [DEFAULT_EMBEDDING_MODEL]
 
 
 # Fonction pour changer de page


### PR DESCRIPTION
## What does this PR do?

Replaces hardcoded values in [rag_app.app.py] with predefined default variables declared at the top of the file.

### Why this change?

- Improves code clarity
- Avoids duplication
- Makes it easier to change default settings in a single place

Let me know if anything needs adjusting — happy to update!
