### PR TITLE
Docs: add venv activation step in instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,15 @@ ollama pull nomic-embed-text
 
 ## Utilisation
 
+### Activer l'environnement virtuel
+Selon votre système d'exploitation :
+```bash
+# Linux / MacOS :
+source .venv/bin/activate
+# Windows :
+.venv\Scripts\activate
+```
+
 ### Lancer l'application
 
 ```bash


### PR DESCRIPTION
## What this PR does

Adds missing virtual environment creation and activation instructions in the Usage section of the README.

### Why this change

- Clarifies the recommended setup for Python projects
- Improves onboarding for new contributors, especially on Windows

Let me know if you'd prefer this as an issue first — happy to adapt.
